### PR TITLE
Fixed bug reported in issue #4

### DIFF
--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+script_dir=/host
 
 $script_dir/scripts/install_packages.sh
 

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -4,6 +4,6 @@ script_dir=/host
 
 $script_dir/scripts/install_packages.sh
 
-if [ ! -d $HOME/opm-build-scripts ]; then
-	ln -s $script_dir/scripts $HOME/opm-build-scripts
+if [ ! -d /home/vagrant/opm-build-scripts ]; then
+	ln -s $script_dir/scripts /home/vagrant/opm-build-scripts
 fi


### PR DESCRIPTION
This addresses issue #4 .

The problem was that vagrant copies, or somehow moves it into the file /tmp/vagrant-shell, and thereby had broken the link to the other scripts.