### PR TITLE
added: allow building docker image against nightly builds

### DIFF
--- a/docker_opm_user/Dockerfile
+++ b/docker_opm_user/Dockerfile
@@ -2,37 +2,50 @@
 # for OPM, which then is easy to publish on docker hub
 # or similar.
 
-# Useful commands use: 
+# Useful commands use:
 # $ docker build -t opm_docker_image .
+# $ docker build --build-arg opm_version=testing-t opm_docker_image .
+# $ docker build --build-arg opm_version=nightly -t opm_docker_image .
+# $ docker build --build-arg opm_version=2017-09-25 -t opm_docker_image .
 # $ docker tag opm_docker_image openporousmedia/opmreleases:<version_number>
 # $ docker login
 # $ docker push
 # $ docker run -v <HOST_DIR>:/shared_host opm_docker_image flow output_dir="/shared_host/output" "/shared_host/<DECK>"
 
 # Use most recent version of ubuntu
-FROM ubuntu:latest
+FROM ubuntu:xenial
+
+ARG opm_version=release
 
 # Make sure we have updated URLs to packages etc.
 RUN apt-get update -y
 
 # Packages needed for add-apt-repository
-RUN apt-get install -y python-software-properties software-properties-common
+RUN apt-get install -y python-software-properties software-properties-common wget
 
-# Add PPA for the OPM packages 
-##########################################################
-##########  (NOTE: check repository here!) #############
-##########################################################
+# Add apt-repo for the OPM packages
 # For the release repository, we should use "ppa:opm/ppa"
 # For the testing repository, we should use "ppa:opm/testing"
-RUN add-apt-repository -y ppa:opm/ppa
+# For the nightly repository, we should use http://opm-project.org/package/xenial-nightly
+RUN if [ "$opm_version" = "release" ]; then apt-add-repository ppa:opm/ppa; fi
+RUN if [ "$opm_version" = "testing" ]; then apt-add-repository ppa:opm/testing; fi
+
+RUN if test "$opm_version" != "release" && test "$opm_version" != "testing"; then  wget -qO - http://opm-project.org/package/nightly-xenial/repokey.gpg | apt-key add -; fi
+
+RUN if test "$opm_version" != "release" && test "$opm_version" != "testing"; then apt-add-repository http://opm-project.org/package/nightly-xenial; fi
 
 # Update package list again
 RUN apt-get update -y
 
 # OPM packages
-RUN apt-get install libopm-core1 -y
-RUN apt-get install libopm-simulators1-bin -y
-RUN apt-get install libopm-upscaling1-bin -y
+RUN if test "$opm_version" = "release" || test "$opm_version" = "testing" || test "$opm_version" = "nightly"; then apt-get install -y libopm-simulators1-bin; else apt-get install -y libopm-simulators1-bin=$opm_version* \
+                                       libopm-simulators1=$opm_version* \
+                                       libopm-core1=$opm_version* \
+                                       libopm-grid1=$opm_version* \
+                                       libopm-output1=$opm_version* \
+                                       libopm-parser1=$opm_version* \
+                                       libopm-common1=$opm_version* \
+                                       libecl1=$opm_version*; fi
 RUN apt-get install openmpi-bin -y
 
 # Other utilities that are required by tutorials etc.
@@ -41,3 +54,6 @@ RUN apt-get install unzip -y
 # Create shared directory
 RUN mkdir /shared_host
 VOLUME /shared_host
+
+RUN adduser opm
+USER opm


### PR DESCRIPTION
use --build-arg opm_version=release|testing|nightly|specific-date when building the docker image. defaults to release
changed: run as user 'opm' inside container
changed: use ubuntu xenial, not latest