### PR TITLE
update vagrant setup to Ubuntu 16.04

### DIFF
--- a/vagrant_opm_user/Vagrantfile
+++ b/vagrant_opm_user/Vagrantfile
@@ -10,13 +10,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "chef/ubuntu-14.04"
+  config.vm.box = "bento/ubuntu-16.04"
   
   config.vm.provision :shell, :path => "bootstrap.sh"
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
-  config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+  config.vm.box_url = "https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-vagrant.box"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
@@ -58,7 +58,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # information on available options.
 config.vm.provider "virtualbox" do |v|
   #v.gui = true
-  v.memory = 2048
+  v.memory = 4096
   v.cpus = 2
 end
 

--- a/vagrant_opm_user/bootstrap.sh
+++ b/vagrant_opm_user/bootstrap.sh
@@ -19,10 +19,8 @@ sudo add-apt-repository -y ppa:opm/ppa
 sudo apt-get update -y
 
 # OPM packages
-sudo apt-get install libopm-core1-bin -y
-sudo apt-get install libopm-simulators1-bin -y
-sudo apt-get install libopm-upscaling1-bin -y
-sudo apt-get install openmpi-bin -y
+sudo apt-get install -y mpi-default-bin
+sudo apt-get install -y libopm-simulators-bin
 
 # Other utilities that are required by tutorials etc.
 sudo apt-get install unzip -y


### PR DESCRIPTION
I also allocated more memory to the virtual box. It may still not be enough to build the current flow binary from source.  But I think OPM/opm-simulators#1287 will fix this issue. Since all other binaries (flow_ebos, flow_ebos_solvent etc) build fine with 4gb. 