### PR TITLE
fixed: opm-project.org now only allows https

### DIFF
--- a/docker_opm_user/Dockerfile
+++ b/docker_opm_user/Dockerfile
@@ -21,7 +21,7 @@ ARG opm_version=release
 RUN apt-get update -y
 
 # Packages needed for add-apt-repository
-RUN apt-get install -y python-software-properties software-properties-common wget
+RUN apt-get install -y python-software-properties software-properties-common wget apt-transport-https
 
 # Add apt-repo for the OPM packages
 # For the release repository, we should use "ppa:opm/ppa"
@@ -30,9 +30,9 @@ RUN apt-get install -y python-software-properties software-properties-common wge
 RUN if [ "$opm_version" = "release" ]; then apt-add-repository ppa:opm/ppa; fi
 RUN if [ "$opm_version" = "testing" ]; then apt-add-repository ppa:opm/testing; fi
 
-RUN if test "$opm_version" != "release" && test "$opm_version" != "testing"; then  wget -qO - http://opm-project.org/package/nightly-xenial/repokey.gpg | apt-key add -; fi
+RUN if test "$opm_version" != "release" && test "$opm_version" != "testing"; then  wget -qO - https://opm-project.org/package/nightly-xenial/repokey.gpg | apt-key add -; fi
 
-RUN if test "$opm_version" != "release" && test "$opm_version" != "testing"; then apt-add-repository http://opm-project.org/package/nightly-xenial; fi
+RUN if test "$opm_version" != "release" && test "$opm_version" != "testing"; then apt-add-repository https://opm-project.org/package/nightly-xenial; fi
 
 # Update package list again
 RUN apt-get update -y


### PR DESCRIPTION
should restore nightly build execution on jenkins.