### PR TITLE
add new required repo to rh6/rh7 Dockerfile

### DIFF
--- a/docker_opm_user/Dockerfile.rh6
+++ b/docker_opm_user/Dockerfile.rh6
@@ -13,7 +13,7 @@ FROM centos:6
 ARG opm_version=release
 
 # Add yum repo
-RUN yum install -y yum-utils epel-release
+RUN yum install -y yum-utils epel-release centos-release-scl
 RUN if [ "$opm_version" = "release" ]; then yum-config-manager --add-repo https://www.opm-project.org/package/opm.repo; fi
 
 RUN if [ "$opm_version" = "nightly" ]; then yum-config-manager --add-repo https://www.opm-project.org/package/opm-nightly.repo; fi

--- a/docker_opm_user/Dockerfile.rh7
+++ b/docker_opm_user/Dockerfile.rh7
@@ -13,7 +13,7 @@ FROM centos:7
 ARG opm_version=release
 
 # Add yum repo
-RUN yum install -y yum-utils epel-release wget
+RUN yum install -y yum-utils epel-release wget centos-release-scl
 RUN if [ "$opm_version" = "release" ]; then yum-config-manager --add-repo https://www.opm-project.org/package/opm.repo; fi
 
 RUN if [ "$opm_version" = "nightly" ]; then yum-config-manager --nogpgcheck --add-repo https://www.opm-project.org/package/opm-nightly.repo; fi


### PR DESCRIPTION
After the new usage of boost 1.58, we now require the scl repo as well. Update dockerfile's accordingly.