### PR TITLE
make sure opmcommon is built before processing opm-simulators

### DIFF
--- a/opm-super/CMakeLists.txt
+++ b/opm-super/CMakeLists.txt
@@ -28,5 +28,6 @@ set(BUILD_TESTING 1)
 
 add_subdirectory(opm-simulators)
 add_dependencies(opmsimulators opmgrid)
+add_dependencies(opm-simulators_prepare opmcommon)
 add_subdirectory(opm-upscaling)
 add_dependencies(opmupscaling opmgrid)


### PR DESCRIPTION
the ebos objects do not depend directly on opm-common, and thus
they are can be built before the generated headers, which are
requires, are in place. we can now use this to ensure the
generated headers are in place before proceeding.

Requires https://github.com/OPM/opm-simulators/pull/2278