### PR TITLE
Fix Old-Style Backquote

### DIFF
--- a/eclipse.el
+++ b/eclipse.el
@@ -70,7 +70,7 @@
       nil)
     (defmacro defface (&rest args) nil)
     (defmacro defcustom (var value doc &rest args)
-      (` (defvar (, var) (, value) (, doc))))))
+      `(defvar (, var) (, value) (, doc)))))
 ;; compatibility
 (if (string-match "X[Ee]macs" emacs-version)
     (progn


### PR DESCRIPTION
Otherwise, the file won't load in recent versions of Emacs (27+).