### PR TITLE
Python package to generate PVT tables

### DIFF
--- a/pvt-tables/README.md
+++ b/pvt-tables/README.md
@@ -1,0 +1,41 @@
+# PVT tables
+
+Generate PVT tables with Coolprop Python package.
+
+**_OBS_**: Only density and enthalpy tables at the moment.
+
+## Setup
+
+Generate a [virtual environment](https://docs.python.org/3/library/venv.html) (strongly recommended) and install
+requirements:
+
+```python
+pip install -r requirements.txt
+```
+
+## Usage
+
+To get the program help page:
+
+```python
+python3 opm_tables_coolprop.py -h
+```
+
+The output from the program is a ```<comp>tables.inc``` file where ```comp``` is the component name. The include file
+can be used to replace ```co2tables.inc``` or ```h2tables.inc``` in ```opm-common```, or generate new tables for other
+components.
+
+## Example
+
+To generate tables for CO2 at temperature and pressure ranges of ```T = [300 K, 400 K]``` and ```P = [1e5 Pa, 100e5
+Pa]```, respectively, with 100 points in each :
+
+```python
+python3 opm_tables_coolprop.py -t1 300 -t2 400 -nt 100 -p1 1e5 -p2 100e5 -np 100 -c CO2
+```
+
+## Dependencies
+
+* [Coolprop](http://www.coolprop.org/)
+* [Mako](https://www.makotemplates.org/)
+* [Numpy](https://numpy.org/)

--- a/pvt-tables/opm_tables_coolprop.py
+++ b/pvt-tables/opm_tables_coolprop.py
@@ -1,3 +1,25 @@
+"""
+    Copyright 2023 NORCE.
+
+    This file is part of the Open Porous Media project (OPM).
+
+    OPM is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    OPM is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+    Consult the COPYING file in the top-level source directory of this
+    module for the precise wording of the license and the list of
+    copyright holders.
+"""
 from CoolProp import CoolProp as cp
 import numpy as np
 from tqdm import tqdm

--- a/pvt-tables/opm_tables_coolprop.py
+++ b/pvt-tables/opm_tables_coolprop.py
@@ -1,0 +1,129 @@
+from CoolProp import CoolProp as cp
+import numpy as np
+from tqdm import tqdm
+from mako.template import Template
+import argparse
+
+
+def generate_table(min_temp, max_temp, ntemp, min_pres, max_pres, npres, comp, tref=None, pref=None):
+    """
+    Generate OPM tables for a component
+
+    Parameters
+    ----------
+    min_temp : float
+        Min. temperature [K]
+    max_temp : float
+        Max. temperature [K]
+    ntemp : int
+        Number of temperature points
+    min_pres : float
+        Min. pressure [Pa]
+    max_pres : float
+        Max. pressure [Pa]
+    npres : int
+        Number of pressure points
+    comp : str
+        Component name, see http://www.coolprop.org/fluid_properties/PurePseudoPure.html
+    tref : float, optional
+        Reference temperature
+    pref : float, optional
+        Reference pressure
+    """
+    # Generate pressure and temperature values
+    pres = np.linspace(min_pres, max_pres, npres)
+    temp = np.linspace(min_temp, max_temp, ntemp)
+
+    # Init. density and enthalpy output from Coolprops
+    dens = np.zeros((ntemp, npres))  # kg/m3
+    enth = np.zeros((ntemp, npres))  # J/kg
+
+    # Instantiate progress bar
+    pbar = tqdm(total=(temp.size * 2), ncols=100, desc='Progress')
+
+    # Set reference temperature and pressure in Coolprop for enthalpy calculations
+    if tref is not None and pref is not None:
+        dmolar = cp.PropsSI('Dmolar', 'T', tref, 'P', pref, comp)
+        cp.set_reference_state(comp, tref, dmolar, 0.0, 0.0)
+
+    # Calculate density and enthalpy from Coolprops
+    for i, t in enumerate(temp):
+            # Density
+            dens[i, :] = cp.PropsSI('D', 'T', t, 'P', pres, comp)
+            pbar.update(1)
+
+            # Enthalpy
+            enth[i, :] = cp.PropsSI('H', 'T', t, 'P', pres, comp)
+            pbar.update(1)
+    
+    # Generate template with mako
+    mako_dict = {"minTemp": min_temp, "maxTemp": max_temp, "nTemp": ntemp, "minPress": min_pres, 
+                 "maxPress" : max_pres, "nPress": npres, "density": dens, "enthalpy": enth, "comp": comp,
+                 "refT" : tref, "refP" : pref}
+    template = Template(filename='table_coolprop.mako')
+    filled_template = template.render(**mako_dict)
+    
+    # Write <comp>tables.inc using the filled-out mako template
+    with open(f'{comp.lower()}tables.inc', 'w', encoding='utf-8') as fid:
+        fid.write(filled_template)
+
+
+if __name__ == '__main__':
+    #
+    # CLI
+    #
+    parser = argparse.ArgumentParser(
+        description="This script generates tables for a components' fluid properties \n"
+        "(density and enthalpy) using CoolProp (http://www.coolprop.org).\n"
+    )
+    parser._optionals.title = 'arguments '
+    parser.add_argument(
+        "-t1", "--min_temp", required=True, type=float, help="The minimum temperature in K."
+    )
+    parser.add_argument(
+        "-t2", "--max_temp", required=True, type=float, help="The maximum temperature in K."
+    )
+    parser.add_argument(
+        "-nt",
+        "--n_temp",
+        required=True,
+        type=int,
+        help="The number of temperature sampling points."
+        "min_temp is the first sampling point, max_temp the last.",
+    )
+    parser.add_argument(
+        "-p1", "--min_press", required=True, type=float, help="The minimum pressure in Pascal."
+    )
+    parser.add_argument(
+        "-p2", "--max_press", required=True, type=float, help="The maximum pressure in Pascal."
+    )
+    parser.add_argument(
+        "-np",
+        "--n_press",
+        required=True,
+        type=int,
+        help="The number of pressure sampling points."
+        "min_press is the first sampling point, max_press the last.",
+    )
+    parser.add_argument(
+        "-c", "--comp_name", required=True, help="The component name, see CoolProp website."
+    )
+    parser.add_argument(
+        "-tref", "--ref_temp", required=False, type=float, help="Reference temperature in K. [OPTIONAL]"
+    )
+    parser.add_argument(
+        "-pref", "--ref_press", required=False, type=float, help="Reference pressure in K. [OPTIONAL]"
+    )
+
+    # Parse CLI arguments
+    cmd_args = parser.parse_args()
+
+    # Check if only one of tref and pref have been inputted
+    if (cmd_args.ref_temp is not None and cmd_args.ref_press is None) or \
+        (cmd_args.ref_temp is None and cmd_args.ref_press is not None):
+        parser.error('-tref (or --ref_temp) and -pref (or --ref_press) must be given together!')
+
+    # Run
+    generate_table(min_temp=cmd_args.min_temp, max_temp=cmd_args.max_temp, ntemp=cmd_args.n_temp, 
+                   tref=cmd_args.ref_temp, min_pres=cmd_args.min_press, max_pres=cmd_args.max_press, 
+                   npres=cmd_args.n_press, pref=cmd_args.ref_press, comp=cmd_args.comp_name)

--- a/pvt-tables/requirements.txt
+++ b/pvt-tables/requirements.txt
@@ -1,0 +1,4 @@
+numpy>=1.24.2
+CoolProp>=6.4.1
+Mako>=1.2.4
+tqdm>=4.65.0

--- a/pvt-tables/table_coolprop.mako
+++ b/pvt-tables/table_coolprop.mako
@@ -1,0 +1,127 @@
+#ifndef ${comp.upper()}TABLES_INC
+#define ${comp.upper()}TABLES_INC
+
+/* The data has been calculated using the CoolProp Python package https://doi.org/10.1021/ie4033999.
+*
+* THIS AN AUTO-GENERATED FILE! DO NOT EDIT IT!
+*
+* Bell, Ian H. and Wronski, Jorrit and Quoilin, Sylvain and Lemort, Vincent
+* Pure and Pseudo-pure Fluid Thermophysical Property Evaluation and
+* the Open-Source Thermophysical Property Library CoolProp
+* Industrial & Engineering Chemistry Research, 53(6), 2014
+* DOI: 10.1021/ie4033999
+*
+* Temperature range: ${'{0:.3f}'.format(minTemp)} K to ${'{0:.3f}'.format(maxTemp)} K, using ${nTemp} sampling points
+* Pressure range: ${'{0:.3f}'.format(minPress/1e6)} MPa to ${'{0:.3f}'.format(maxPress/1e6)} MPa, using ${nPress} sampling points
+% if refP is not None and refT is not None:
+* Reference temperature and pressure: ${refT} K and ${refP/1e6} MPa
+% else:
+* Reference state from Coolprop website (http://www.coolprop.org/coolprop/HighLevelAPI.html#reference-states):
+*   Enthalpy = 200 kJ/kg (and entropy = 1 kJ/kg/K) at 0C saturated liquid
+% endif
+*
+* Generated using:
+*
+% if refP is None and refT is None:
+* >> python3 opm_tables_coolprop.py -t1 ${minTemp} -t2 ${maxTemp} -nt ${nTemp} -p1 ${minPress} -p2 ${maxPress} -np ${nPress} -c ${comp}
+% else:
+* >> python3 opm_tables_coolprop.py -t1 ${minTemp} -t2 ${maxTemp} -nt ${nTemp} -tref ${refT} -p1 ${minPress} -p2 ${maxPress} -np ${nPress} -pref ${refP} -c ${comp}
+% endif
+* 
+*/
+struct TabulatedDensityTraits {
+    typedef double Scalar;
+    static const char  *name;
+    static const int    numX = ${nTemp};
+    static const Scalar xMin;
+    static const Scalar xMax;
+    static const int    numY = ${nPress};
+    static const Scalar yMin;
+    static const Scalar yMax;
+
+    static const std::vector<std::vector<Scalar>> vals;
+};
+
+inline const double TabulatedDensityTraits::xMin = ${'{0:.15e}'.format(minTemp)};
+inline const double TabulatedDensityTraits::xMax = ${'{0:.15e}'.format(maxTemp)};
+inline const double TabulatedDensityTraits::yMin = ${'{0:.15e}'.format(minPress)};
+inline const double TabulatedDensityTraits::yMax = ${'{0:.15e}'.format(maxPress)};
+inline const char  *TabulatedDensityTraits::name = "density";
+
+inline const std::vector<std::vector<double>> TabulatedDensityTraits::vals =
+{
+% for i in range(nTemp):
+${'\t{'}
+% for j in range(nPress):
+%if (j+1) % 5 == 0:
+${'\t\t{0:.15e}'.format(density[i][j])}${'\n' if loop.last else ',\n'}\
+%else:
+${'\t\t{0:.15e}'.format(density[i][j])}${'\n' if loop.last else ','}\
+%endif
+% endfor
+${'\t}' if loop.last else '\t},'}
+% endfor
+};
+
+struct TabulatedEnthalpyTraits {
+    typedef double Scalar;
+    static const char  *name;
+    static const int    numX = ${nTemp};
+    static const Scalar xMin;
+    static const Scalar xMax;
+    static const int    numY = ${nPress};
+    static const Scalar yMin;
+    static const Scalar yMax;
+    static const std::vector<std::vector<Scalar>> vals;
+};
+
+inline const double TabulatedEnthalpyTraits::xMin = ${'{0:.15e}'.format(minTemp)};
+inline const double TabulatedEnthalpyTraits::xMax = ${'{0:.15e}'.format(maxTemp)};
+inline const double TabulatedEnthalpyTraits::yMin = ${'{0:.15e}'.format(minPress)};
+inline const double TabulatedEnthalpyTraits::yMax = ${'{0:.15e}'.format(maxPress)};
+inline const char  *TabulatedEnthalpyTraits::name = "enthalpy";
+
+inline const std::vector<std::vector<double>> TabulatedEnthalpyTraits::vals =
+{
+% for i in range(nTemp):
+${'\t{'}
+% for j in range(nPress):
+%if (j+1) % 5 == 0:
+${'\t\t{0:.15e}'.format(enthalpy[i][j])}${'\n' if loop.last else ',\n'}\
+%else:
+${'\t\t{0:.15e}'.format(enthalpy[i][j])}${'\n' if loop.last else ','}\
+%endif
+% endfor
+${'\t}' if loop.last else '\t},'}
+% endfor
+};
+
+typedef Opm::UniformTabulated2DFunction< double > TabulatedFunction;
+
+// this class collects all the tabulated quantities in one convenient place
+struct ${comp.upper()}Tables {
+   static const TabulatedFunction   tabulatedEnthalpy;
+   static const TabulatedFunction   tabulatedDensity;
+   static constexpr double brineSalinity = 1.000000000000000e-01;
+};
+
+inline const TabulatedFunction ${comp.upper()}Tables::tabulatedEnthalpy
+    {TabulatedEnthalpyTraits::xMin,
+     TabulatedEnthalpyTraits::xMax,
+     TabulatedEnthalpyTraits::numX,
+     TabulatedEnthalpyTraits::yMin,
+     TabulatedEnthalpyTraits::yMax,
+     TabulatedEnthalpyTraits::numY,
+     TabulatedEnthalpyTraits::vals};
+
+inline const TabulatedFunction ${comp.upper()}Tables::tabulatedDensity
+    {TabulatedDensityTraits::xMin,
+     TabulatedDensityTraits::xMax,
+     TabulatedDensityTraits::numX,
+     TabulatedDensityTraits::yMin,
+     TabulatedDensityTraits::yMax,
+     TabulatedDensityTraits::numY,
+     TabulatedDensityTraits::vals};
+
+
+#endif /* ${comp.upper()}TABLES_INC */


### PR DESCRIPTION
A simple Python package to generate PVT tables like  `co2tables.inc` and `h2tables.inc` in `opm-common`.