### PR TITLE
Make Vagrant use Ubuntu 22.04

### DIFF
--- a/vagrant_opm_user/Vagrantfile
+++ b/vagrant_opm_user/Vagrantfile
@@ -10,13 +10,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "bento/ubuntu-16.04"
+  config.vm.box = "bento/ubuntu-22.04"
   
   config.vm.provision :shell, :path => "bootstrap.sh"
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
-  config.vm.box_url = "https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-vagrant.box"
+  config.vm.box_url = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64-vagrant.box"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,

--- a/vagrant_opm_user/bootstrap.sh
+++ b/vagrant_opm_user/bootstrap.sh
@@ -10,7 +10,7 @@ set -x
 sudo apt-get update -y
 
 # Packages needed for add-apt-repository
-sudo apt-get install -y python-software-properties software-properties-common
+sudo apt-get install -y python3-software-properties software-properties-common
 
 # Add PPA for the OPM packages
 sudo add-apt-repository -y ppa:opm/ppa


### PR DESCRIPTION
It was still on version 16.04 which has not OPM packages. Some people still get here from our website and then wonder why there is no OPM installed.