### PR TITLE
[bugfix,opmrun] Specify encoding when reading description file

### DIFF
--- a/opmrun/setup.py
+++ b/opmrun/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 from opmrun import __version__
 
-with open("DESCRIPTION.md", "r") as fh:
+with open("DESCRIPTION.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
Otherwise I get an encoding error on the OS that is not to be named.