### PR TITLE
Permit Command Line Arguments for Upstream and Branch

### DIFF
--- a/release-scripts/opm-backport-pr.sh
+++ b/release-scripts/opm-backport-pr.sh
@@ -1,49 +1,55 @@
 #!/bin/sh
 #
-# A small script to backport a full PR onto the release. Takes the PR number
-# as the only argument and assumes that remote https://github.com/OPM/opm-module
-# is called upstream. You need to adjust the RELEASE variable below
+# A small script to back-port a full PR onto a release branch.  Takes
+# the PR number as a mandatory command line argument and, optionally,
+# two more arguments--one for the release ID (e.g., 2025.04) and one
+# for the name of the upstream repository
+# https://github.com/OPM/opm-module (default "upstream").
 #
-# Before running, do 'git remote update' to ensure the commits you want are in your repo.
-# Run the script from the local repository of the module you are backporting in.
+# The script assumes that it's being run in a local workspace of an
+# OPM module.
+#
+# Before running this script, please run 'git remote update' to ensure
+# the commits you want are in your local repository of the module for
+# which you're back-porting PRs.  Then, run the script from this local
+# repository.
+#
+# Example: Back-port PR 1729 of module opm-grid to release
+# branch release/2024.10 from 'upstream' remote repository (default).
+#
+#    cd path/to/opm-grid
+#    git remote update --prune
+#
+#    sh path/to/opm-utilities/release-scripts/opm-backport-pr.sh 1729 2024.10
+
+if [ $# -lt 1 ]; then
+    echo "Must supply at least the PR number (e.g., '8192') as an argument"
+    exit 2 # Status code '2' is bash(1) convention for incorrect usage.
+fi
+
 set -e
 set -x
-PR=$1 # the PR number
-RELEASE=2024.04
-UPSTREAM=upstream #The remote name of the repo https://github.com/OPM/<opm-module>
-git checkout release/$RELEASE
+
+# PR number.
+PR=$1
+
+# Release ID.
+RELEASE=${2:-2025.04}
+
+# Local name of the main upstream repo, https://github.com/OPM/<opm-module>
+UPSTREAM=${3:-upstream}
+
+# Source branch from which to merge PRs.
+src_branch=master
+
+git switch release/$RELEASE
 git pull --ff-only $UPSTREAM release/$RELEASE
-SHA="$(git log --oneline upstream/master | grep "Merge pull request #$PR"| head -n 1 | cut -d \  -f 1)"
+
+SHA=$(git log --oneline ${UPSTREAM}/${src_branch} | \
+          awk -v search="Merge pull request #${PR}[[:space:]]+" \
+              '$0~search{print $1; exit}')
 FSHA="$(git show --pretty="format:%h" $SHA~)"
+
 echo "backporting PR $PR from $FSHA to $SHA"
-git rebase --onto release/$RELEASE $FSHA $SHA && git checkout -b backport-of-pr-$PR
-
-
-
-# https://github.com/OPM/opm-common/pull/3186
-# https://github.com/OPM/opm-common/pull/3192
-# https://github.com/OPM/opm-common/pull/3193
-# https://github.com/OPM/opm-common/pull/3195
-# https://github.com/OPM/opm-common/pull/3198
-# https://github.com/OPM/opm-common/pull/3203
-# https://github.com/OPM/opm-common/pull/3205
-
-# https://github.com/OPM/opm-models/pull/741
-# https://github.com/OPM/opm-models/pull/746
-# https://github.com/OPM/opm-models/pull/748
-
-# https://github.com/OPM/opm-simulators/pull/4185
-# https://github.com/OPM/opm-simulators/pull/4187
-# https://github.com/OPM/opm-simulators/pull/4194
-# https://github.com/OPM/opm-simulators/pull/4200
-# https://github.com/OPM/opm-simulators/pull/4207
-# https://github.com/OPM/opm-simulators/pull/4217
-# https://github.com/OPM/opm-simulators/pull/4223
-
-# https://github.com/OPM/opm-upscaling/pull/367
-
-
-# https://github.com/OPM/opm-simulators/pull/4212
-# https://github.com/OPM/opm-simulators/pull/4242
-# https://github.com/OPM/opm-simulators/pull/4243
-# https://github.com/OPM/opm-simulators/pull/4249
+git rebase --onto release/$RELEASE $FSHA $SHA && \
+    git switch --create=backport-of-pr-$PR


### PR DESCRIPTION
That way, users (release managers) won't have to edit the script if they don't want to.

Default values from 2024.10 release.