### PR TITLE
Add linear solver configuration for system-cpr/cprw article.

### DIFF
--- a/flow/settings/repo_json_ecmor26/README.md
+++ b/flow/settings/repo_json_ecmor26/README.md
@@ -1,0 +1,4 @@
+This directory contains linear solver configurations for OPM Flow
+(usage: --linear-solver=name_of_configuration.json) used in the
+ECMOR 2026 article "Constrained Pressure Residual Preconditioners
+with Well Contributions for Complex Reservoirs".

--- a/flow/settings/repo_json_ecmor26/linear_solver_cpr.json
+++ b/flow/settings/repo_json_ecmor26/linear_solver_cpr.json
@@ -1,0 +1,45 @@
+{
+    "maxiter": "20",
+    "tol": "0.0050000000000000001",
+    "verbosity": "0",
+    "solver": "bicgstab",
+    "preconditioner": {
+        "type": "cpr",
+        "use_well_weights": "false",
+        "add_wells": "false",
+        "weight_type": "trueimpes",
+        "pre_smooth": "0",
+        "post_smooth": "1",
+        "finesmoother": {
+            "type": "paroverilu0",
+            "relaxation": "1"
+        },
+        "verbosity": "0",
+        "coarsesolver": {
+            "maxiter": "3",
+            "tol": "0.0010000000000000001",
+            "solver": "loopsolver",
+            "verbosity": "0",
+            "preconditioner": {
+                "type": "amg",
+                "alpha": "0.33333333333300003",
+                "relaxation": "1",
+                "iterations": "1",
+                "coarsenTarget": "1200",
+                "pre_smooth": "1",
+                "post_smooth": "1",
+                "beta": "0",
+                "smoother": "ilu0",
+                "verbosity": "0",
+                "maxlevel": "15",
+                "skip_isolated": "0",
+                "accumulate": "1",
+                "prolongationdamping": "1",
+                "maxdistance": "2",
+                "maxconnectivity": "15",
+                "maxaggsize": "6",
+                "minaggsize": "4"
+            }
+        }
+    }
+}

--- a/flow/settings/repo_json_ecmor26/linear_solver_cprw.json
+++ b/flow/settings/repo_json_ecmor26/linear_solver_cprw.json
@@ -1,0 +1,45 @@
+{
+    "maxiter": "20",
+    "tol": "0.0050000000000000001",
+    "verbosity": "0",
+    "solver": "bicgstab",
+    "preconditioner": {
+        "type": "cprw",
+        "use_well_weights": "false",
+        "add_wells": "true",
+        "weight_type": "trueimpes",
+        "pre_smooth": "0",
+        "post_smooth": "1",
+        "finesmoother": {
+            "type": "paroverilu0",
+            "relaxation": "1"
+        },
+        "verbosity": "0",
+        "coarsesolver": {
+            "maxiter": "3",
+            "tol": "0.0010000000000000001",
+            "solver": "loopsolver",
+            "verbosity": "0",
+            "preconditioner": {
+                "type": "amg",
+                "alpha": "0.33333333333300003",
+                "relaxation": "1",
+                "iterations": "1",
+                "coarsenTarget": "1200",
+                "pre_smooth": "1",
+                "post_smooth": "1",
+                "beta": "0",
+                "smoother": "ilu0",
+                "verbosity": "0",
+                "maxlevel": "15",
+                "skip_isolated": "0",
+                "accumulate": "1",
+                "prolongationdamping": "1",
+                "maxdistance": "2",
+                "maxconnectivity": "15",
+                "maxaggsize": "6",
+                "minaggsize": "4"
+            }
+        }
+    }
+}

--- a/flow/settings/repo_json_ecmor26/linear_solver_system_cpr.json
+++ b/flow/settings/repo_json_ecmor26/linear_solver_system_cpr.json
@@ -1,0 +1,71 @@
+{
+    "maxiter": "20",
+    "tol": "0.0050000000000000001",
+    "verbosity": "0",
+    "solver": "bicgstab",
+    "preconditioner": {
+        "type": "system_cpr",
+        "reservoir_smoother": {
+            "maxiter": "1",
+            "tol": "0.0050000000000000001",
+            "verbosity": "0",
+            "solver": "preconditioner2inverseoperator",
+            "preconditioner": {
+                "type": "paroverilu0",
+                "relaxation": "1"
+            }
+        },
+        "reservoir_solver": {
+            "maxiter": "1",
+            "tol": "0.0050000000000000001",
+            "verbosity": "0",
+            "solver": "preconditioner2inverseoperator",
+            "preconditioner": {
+                "type": "cpr",
+                "relaxation": "1",
+                "use_well_weights": "false",
+                "add_wells": "false",
+                "weight_type": "trueimpes",
+                "pre_smooth": "0",
+                "post_smooth": "0",
+                "finesmoother": {
+                    "type": "jac",
+                    "relaxation": "1"
+                },
+                "verbosity": "0",
+                "coarsesolver": {
+                    "maxiter": "3",
+                    "tol": "0.0010000000000000001",
+                    "solver": "loopsolver",
+                    "verbosity": "0",
+                    "preconditioner": {
+                        "type": "amg",
+                        "alpha": "0.33333333333300003",
+                        "relaxation": "1",
+                        "iterations": "1",
+                        "coarsenTarget": "1200",
+                        "pre_smooth": "1",
+                        "post_smooth": "1",
+                        "beta": "0",
+                        "smoother": "ilu0",
+                        "verbosity": "0",
+                        "maxlevel": "15",
+                        "skip_isolated": "0",
+                        "accumulate": "1",
+                        "prolongationdamping": "1",
+                        "maxdistance": "2",
+                        "maxconnectivity": "15",
+                        "maxaggsize": "6",
+                        "minaggsize": "4"
+                    }
+                }
+            }
+        },
+        "well_solver": {
+            "maxiter": "1",
+            "tol": "0.0050000000000000001",
+            "verbosity": "0",
+            "solver": "umfpack"
+        }
+    }
+}

--- a/flow/settings/repo_json_ecmor26/linear_solver_system_cprw.json
+++ b/flow/settings/repo_json_ecmor26/linear_solver_system_cprw.json
@@ -1,0 +1,71 @@
+{
+    "maxiter": "20",
+    "tol": "0.0050000000000000001",
+    "verbosity": "0",
+    "solver": "bicgstab",
+    "preconditioner": {
+        "type": "system_cprw",
+        "reservoir_smoother": {
+            "maxiter": "1",
+            "tol": "0.0050000000000000001",
+            "verbosity": "0",
+            "solver": "preconditioner2inverseoperator",
+            "preconditioner": {
+                "type": "paroverilu0",
+                "relaxation": "1"
+            }
+        },
+        "reservoir_solver": {
+            "maxiter": "1",
+            "tol": "0.0050000000000000001",
+            "verbosity": "0",
+            "solver": "preconditioner2inverseoperator",
+            "preconditioner": {
+                "type": "cprw",
+                "relaxation": "1",
+                "use_well_weights": "false",
+                "add_wells": "true",
+                "weight_type": "trueimpes",
+                "pre_smooth": "0",
+                "post_smooth": "0",
+                "finesmoother": {
+                    "type": "jac",
+                    "relaxation": "1"
+                },
+                "verbosity": "0",
+                "coarsesolver": {
+                    "maxiter": "3",
+                    "tol": "0.0010000000000000001",
+                    "solver": "loopsolver",
+                    "verbosity": "0",
+                    "preconditioner": {
+                        "type": "amg",
+                        "alpha": "0.33333333333300003",
+                        "relaxation": "1",
+                        "iterations": "1",
+                        "coarsenTarget": "1200",
+                        "pre_smooth": "1",
+                        "post_smooth": "1",
+                        "beta": "0",
+                        "smoother": "ilu0",
+                        "verbosity": "0",
+                        "maxlevel": "15",
+                        "skip_isolated": "0",
+                        "accumulate": "1",
+                        "prolongationdamping": "1",
+                        "maxdistance": "2",
+                        "maxconnectivity": "15",
+                        "maxaggsize": "6",
+                        "minaggsize": "4"
+                    }
+                }
+            }
+        },
+        "well_solver": {
+            "maxiter": "1",
+            "tol": "0.0050000000000000001",
+            "verbosity": "0",
+            "solver": "umfpack"
+        }
+    }
+}


### PR DESCRIPTION
Intended to preserve configurations referred to in article, while also enabling updating if necessary for later versions of OPM Flow.